### PR TITLE
Unset preset parameter default feature

### DIFF
--- a/src/jalv.c
+++ b/src/jalv.c
@@ -1719,11 +1719,8 @@ jalv_process_command(Jalv* jalv, const char* cmd)
 		jalv_unload_presets(jalv);
 		jalv_load_presets(jalv, jalv_print_preset, NULL);
 	} else if (sscanf(cmd, "preset %1023[-a-zA-Z0-9_:/.%%#]", sym) == 1) {
-		LilvNode* preset = lilv_new_uri(jalv->world, sym);
-		lilv_world_load_resource(jalv->world, preset);
-		jalv_apply_preset(jalv, preset);
+		jalv_command_load_preset(jalv, sym);
 		update_ui_title(jalv);
-		lilv_node_free(preset);
 		//jalv_print_ports(jalv, true, false);
 	} else if (sscanf(cmd, "save preset %1023[-a-zA-Z0-9_:/.%%#, ]", sym) == 1) {
 		jalv_command_save_preset(jalv,sym);

--- a/src/jalv.c
+++ b/src/jalv.c
@@ -247,7 +247,8 @@ create_port(Jalv* jalv, uint32_t port_index, float default_value)
   if (lilv_port_is_a(
         jalv->plugin, port->lilv_port, jalv->nodes.lv2_ControlPort)) {
     port->type    = TYPE_CONTROL;
-    port->control = isnan(default_value) ? 0.0f : default_value;
+    port->defval = isnan(default_value) ? 0.0f : default_value;
+    port->control = port->defval;
     if (!hidden) {
       add_control(&jalv->controls,
                   new_port_control(jalv->world,

--- a/src/jalv.c
+++ b/src/jalv.c
@@ -1227,6 +1227,7 @@ jalv_open(Jalv* const jalv, int* argc, char*** argv)
   jalv->control_in    = (uint32_t)-1;
   jalv->log.urids     = &jalv->urids;
   jalv->log.tracing   = jalv->opts.trace;
+  jalv->unset_default = jalv->opts.unset_default;
 
   zix_sem_init(&jalv->symap_lock, 1);
   zix_sem_init(&jalv->work_lock, 1);
@@ -1723,6 +1724,18 @@ jalv_process_command(Jalv* jalv, const char* cmd)
 		jalv_command_load_preset(jalv, sym);
 		update_ui_title(jalv);
 		//jalv_print_ports(jalv, true, false);
+	} else if (sscanf(cmd, "presetd %1023[-a-zA-Z0-9_:/.%%#]", sym) == 1) {
+		jalv->unset_default = true;
+		jalv_command_load_preset(jalv, sym);
+		update_ui_title(jalv);
+		//jalv_print_ports(jalv, true, false);
+		jalv->unset_default = jalv->opts.unset_default;
+	} else if (sscanf(cmd, "presetn %1023[-a-zA-Z0-9_:/.%%#]", sym) == 1) {
+		jalv->unset_default = false;
+		jalv_command_load_preset(jalv, sym);
+		update_ui_title(jalv);
+		//jalv_print_ports(jalv, true, false);
+		jalv->unset_default = jalv->opts.unset_default;
 	} else if (sscanf(cmd, "save preset %1023[-a-zA-Z0-9_:/.%%#, ]", sym) == 1) {
 		jalv_command_save_preset(jalv,sym);
 		// Rebuild preset menu and update window title
@@ -1736,6 +1749,8 @@ jalv_process_command(Jalv* jalv, const char* cmd)
 		        "  monitors          Print output control values\n"
 		        "  presets           Print available presets\n"
 		        "  preset URI        Set preset\n"
+		        "  presetd URI       Set preset, defaulting unset controls\n"
+		        "  presetn URI       Set preset, never defaulting unset controls\n"
 		        "  save preset [BANK_URI,] LABEL\n"
 		        "                    Save preset (BANK_URI is optional)\n"
 		        "  set INDEX VALUE   Set control value by port index\n"

--- a/src/jalv_console.c
+++ b/src/jalv_console.c
@@ -236,10 +236,10 @@ int
 jalv_frontend_open(Jalv* jalv)
 {
   if (!jalv_run_custom_ui(jalv) && !jalv->opts.non_interactive) {
-  	init_cli_thread(jalv);
+    init_cli_thread(jalv);
     while (zix_sem_try_wait(&jalv->done)) {
-		jalv_update(jalv);
-		usleep(30000);
+      jalv_update(jalv);
+      usleep(30000);
     }
   } else {
     zix_sem_wait(&jalv->done);

--- a/src/jalv_console.c
+++ b/src/jalv_console.c
@@ -235,8 +235,11 @@ jalv_frontend_select_plugin(Jalv* jalv)
 int
 jalv_frontend_open(Jalv* jalv)
 {
-  if (!jalv_run_custom_ui(jalv) && !jalv->opts.non_interactive) {
+  if (!jalv->opts.non_interactive) {
     init_cli_thread(jalv);
+  }
+
+  if (!jalv_run_custom_ui(jalv)) {
     while (zix_sem_try_wait(&jalv->done)) {
       jalv_update(jalv);
       usleep(30000);

--- a/src/jalv_console.c
+++ b/src/jalv_console.c
@@ -42,6 +42,7 @@ print_usage(const char* name, bool error)
           "  -b SIZE      Buffer size for plugin <=> UI communication\n"
           "  -c SYM=VAL   Set control value (e.g. \"vol=1.4\")\n"
           "  -d           Dump plugin <=> UI communication\n"
+          "  -D           Set unset parameters to defaults when loading preset\n"
           "  -h           Display this help and exit\n"
           "  -i           Ignore keyboard input, run non-interactively\n"
           "  -l DIR       Load state from save directory\n"
@@ -139,6 +140,8 @@ jalv_frontend_init(int* argc, char*** argv, JalvOptions* opts)
       opts->non_interactive = true;
     } else if ((*argv)[a][1] == 'd') {
       opts->dump = true;
+    } else if ((*argv)[a][1] == 'D') {
+      opts->unset_default = true;
     } else if ((*argv)[a][1] == 't') {
       opts->trace = true;
     } else if ((*argv)[a][1] == 'n') {

--- a/src/jalv_internal.h
+++ b/src/jalv_internal.h
@@ -118,6 +118,7 @@ struct JalvImpl {
   bool                safe_restore;    ///< Plugin restore() is thread-safe
   JalvFeatures        features;
   const LV2_Feature** feature_list;
+  bool                unset_default;   ///< Set unused to default when loading preset
 };
 
 char*

--- a/src/options.h
+++ b/src/options.h
@@ -29,6 +29,7 @@ typedef struct {
   int      print_controls;  ///< Print control changes to stdout
   int      non_interactive; ///< Do not listen for commands on stdin
   char*    ui_uri;          ///< URI of UI to load
+  int      unset_default;   ///< Unset controls are defaulted when loading preset
 } JalvOptions;
 
 JALV_END_DECLS

--- a/src/port.h
+++ b/src/port.h
@@ -28,6 +28,8 @@ struct Port {
   size_t          buf_size;  ///< Custom buffer size, or 0
   uint32_t        index;     ///< Port index
   float           control;   ///< For control ports, otherwise 0.0f
+  float           defval;    ///< For control ports, otherwise 0.0f
+  bool            is_set;    ///< For control ports: is value set?
 };
 
 JALV_END_DECLS

--- a/src/state.c
+++ b/src/state.c
@@ -120,6 +120,29 @@ jalv_unload_presets(Jalv* jalv)
 }
 
 static void
+set_port_fvalue(Jalv *jalv,
+                 struct Port *port,
+                 const ControlID *control,
+                 float fvalue)
+{
+  if (jalv->play_state != JALV_RUNNING) {
+    // Set value on port struct directly
+    port->control = fvalue;
+  } else {
+    // Send value to plugin (as if from UI)
+    jalv_write_control(jalv, jalv->ui_to_plugin, port->index, fvalue);
+  }
+
+  if (jalv->has_ui) {
+    // Update UI (as if from plugin)
+    jalv_write_control(jalv, jalv->plugin_to_ui, port->index, fvalue);
+  }
+
+  // Print control value to console
+  jalv_print_control(jalv, control, fvalue);
+}
+
+static void
 set_port_value(const char* port_symbol,
                void*       user_data,
                const void* value,
@@ -152,21 +175,9 @@ set_port_value(const char* port_symbol,
     return;
   }
 
-  if (jalv->play_state != JALV_RUNNING) {
-    // Set value on port struct directly
-    port->control = fvalue;
-  } else {
-    // Send value to plugin (as if from UI)
-    jalv_write_control(jalv, jalv->ui_to_plugin, port->index, fvalue);
-  }
 
-  if (jalv->has_ui) {
-    // Update UI (as if from plugin)
-    jalv_write_control(jalv, jalv->plugin_to_ui, port->index, fvalue);
-  }
+  set_port_fvalue(jalv, port, control, fvalue);
 
-  // Print control value to console
-  jalv_print_control(jalv, control, fvalue);
 }
 
 void

--- a/src/state.c
+++ b/src/state.c
@@ -230,7 +230,8 @@ jalv_apply_state(Jalv* jalv, LilvState* state)
     lilv_state_restore(
       state, jalv->instance, set_port_value, jalv, 0, state_features);
 
-    jalv_set_unset_controls_to_defaults(jalv);
+    if (jalv->unset_default)
+      jalv_set_unset_controls_to_defaults(jalv);
 
     if (must_pause) {
       jalv->request_update = true;

--- a/src/state.c
+++ b/src/state.c
@@ -334,3 +334,12 @@ jalv_command_save_preset(Jalv* jalv, char* sym)
 	lilv_node_free(ldir);
 	free(plugin_name);
 }
+
+void
+jalv_command_load_preset(Jalv* jalv, char* sym)
+{
+	LilvNode* preset = lilv_new_uri(jalv->world, sym);
+	lilv_world_load_resource(jalv->world, preset);
+	jalv_apply_preset(jalv, preset);
+	lilv_node_free(preset);
+}

--- a/src/state.h
+++ b/src/state.h
@@ -71,6 +71,9 @@ jalv_save_bank_preset(Jalv*  jalv,
 void
 jalv_command_save_preset(Jalv* jalv, char* sym);
 
+void
+jalv_command_load_preset(Jalv* jalv, char* sym);
+
 int
 jalv_fix_symbol(char* symbol, const char* extra_allowed_chars);
 


### PR DESCRIPTION
Implement a feature whereby unset parameters in a preset file will automatically be set to their default value when loaded by jalv.

The is implemented as non-intrusively as possible: there are two new members in the Port structure, one saving the default value that is loaded from the plugin when it is instantiated, and one is_set flag, used solely when loading a preset in jalv_apply_state(). 

When jalv_apply_state() is called, first the is_set value for all control ports is set to false; it is then set by the set_port_value() callback for each control that is set in the state when calling lilv_state_restore(). After calling this function, all unset controls are set to their default values. This is done in the same context as lilv_state_restore(). The final stage is only executed when either the -D flag has been specified on the command line, or unconditionally the 'presetd' CLI command is used.

We discussed solely having two CLI functions for loading presets, one functioning as before, and one implementing the aforementioned feature, however, that would mean that the graphic versions of jalv such as jalv.gtk3 would either not get the functionality, or the user would have to choose when loading a preset. I therefore opted for a command line switch which can then be set by zynthian_engine_jalv.py on a per-plugin basis, but there are also two CLI commands which force the old and new behavior, 'presetn' and 'presetd', respectively (short for 'preset no defaults' and 'preset defaults').